### PR TITLE
Implement component finder template module, fix fatal bug in init_client

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -687,6 +687,10 @@ class Client:
                             module_loaded = ""
                             self.write_nodestate(nodeState, 5, module_loaded)
 
+            if message.startswith("find:"):
+                import finder
+                finder.respond_start(message, sub_node, log_level)
+
             # Provide server's a means of communicating readiness to clients. This is used during file proxying
             # to form a feedback loop between the proxy and client, that way the client doesn't ever exceed the
             # maximum channel capacity(i.e bandwidth) of it's connection to the proxy server.

--- a/src/client/init_client.py
+++ b/src/client/init_client.py
@@ -8,8 +8,8 @@ port = 3705
 def init(network_architecture):
     x = client.Client()
     x.initialize(port=port, net_architecture=network_architecture, remote_addresses=None,
-                 command_execution=True, default_log_level="Debug", modules=["corecount"],
-                 networkSize=5)
+                 command_execution=True, default_log_level="Info", modules=["corecount"],
+                 net_size=9)
 
 
 if __name__ == "__main__":

--- a/src/inter/modules/finder.py
+++ b/src/inter/modules/finder.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+
+# Allow us to import the client
+this_dir = os.path.dirname(os.path.realpath(__file__))
+os.chdir(this_dir)
+sys.path.insert(0, '../../../client/')
+sys.path.insert(0, '../../../server/')
+sys.path.insert(0, (os.path.abspath('../../inter/misc')))
+import primitives
+import client
+message = "find:this16digittoken"
+
+
+def led_on(shelf_num):
+    shelf_num
+    #interface led
+    #RPI GPIO module
+
+
+
+def respond_start(message, sub_node, log_level):
+    Primitives = primitives.Primitives(sub_node, log_level)
+
+    arguments = Primitives.parse_cmd(message)
+    print(arguments)
+    part_number = arguments[1]
+    print(part_number)
+    """
+    if part_number in inventory:
+        part
+    except:
+        this pi does not have the part
+    
+    """
+
+    ###
+
+
+    """Called by the client's listener_thread when it received a [name]: flag"""
+
+    #find shelf for item num
+    return part_number
+


### PR DESCRIPTION
**Correct a bug in `src/client/init_client`** which tried to pass a non-existent argument to `Client.initialize()`. The argument `networkSize` was refactored to `net_size` to comply with PEP8 without altering the `init_client` script, leading to an `unboundLocalError` upon execution of `src/misc/init_client`.

**Begin implementing** the component-location algorithm with the introduction of the `finder` module (`src/inter/modules/finder.py`). Template code was inserted, but component-location protocol implementation will begin in the near future.