### PR TITLE
Improve protocol stability, squash more peer discovery bugs, clean code...

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -984,8 +984,13 @@ class Client:
 
                 # Get a list of all remote addresses
                 _data = Primitives.get_local_ip()
+
+                print("Local IP: "+_data)
+
                 addresses = [item[1] for item in net_tuple]
                 _data += "\n" + '\n'.join(addresses)
+
+                print("Writing Data: "+_data)
 
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -846,7 +846,7 @@ class Client:
                             print('(sync)Network size: ' + str(network_size))
                             print("(sync)Lines: " + str(existing_lines))
 
-                            if network_size > len(existing_lines):
+                            if is_cluster_rep and network_size > len(existing_lines):
                                 print("(sync)Not done...")
                                 print("(sync) fetching "+page_id+".bin"+"...")
                                 self.broadcast(self.prepare("fetch:" + hosts_pagefile + ":discovery"),

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -730,7 +730,7 @@ class Client:
 
                             if is_cluster_rep:
 
-                                self.broadcast(self.prepare("fetch:" + hosts_pagefile), do_mesh_propagation=True)
+                                self.broadcast(self.prepare("fetch:" + hosts_pagefile), do_mesh_propagation=False)
 
                             module_loaded = ""
                             self.write_nodestate(nodeState, 5, module_loaded)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -987,6 +987,9 @@ class Client:
 
                 # Get a list of all remote addresses
                 _data = Primitives.get_local_ip()
+                addresses = [item[0] for item in net_tuple]
+                _data += "\n" + random.choice(addresses)
+
 
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -645,8 +645,16 @@ class Client:
 
                 page_contents = ''.join(page_lines)
 
-                sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                self.broadcast(sync_msg, do_mesh_propagation=False)
+                if arguments[1] == "discovery":
+                    is_cluster_rep = self.read_nodestate(11)
+
+                    if is_cluster_rep or len(page_lines) == network_size:
+                        sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                        self.broadcast(sync_msg, do_mesh_propagation=False)
+
+                else:
+                    sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                    self.broadcast(sync_msg, do_mesh_propagation=False)
 
             # Write received pagefile data to disk
             if message.startswith("sync:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -630,6 +630,7 @@ class Client:
                             self.broadcast(sync_msg, do_mesh_propagation=False)
 
                 except IndexError:
+                    print("!!!!!")
                     sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                     self.broadcast(sync_msg, do_mesh_propagation=False)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -699,8 +699,11 @@ class Client:
 
                         if is_cluster_rep and network_size > len(page_lines):
                             print("(fetch) syncing "+page_id+".bin"+"...")
-                            sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                            self.broadcast(sync_msg, do_mesh_propagation=False)
+
+                            sync_msg = self.prepare("sync:" + page_id + ":" + page_contents, salt=False)
+                            out_sig = sync_msg[:16]
+                            if out_sig not in message_list:
+                                self.broadcast(sync_msg, do_mesh_propagation=False)
 
                         else:
                             print("(fetch) not syncing "+page_id+".bin"+"..."+"; All contributions"
@@ -709,7 +712,6 @@ class Client:
 
                 # Else if arguments[1] doesn't exist queue a normal fetch: routine
                 except TypeError:
-
                     sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                     self.broadcast(sync_msg, do_mesh_propagation=True)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -658,7 +658,7 @@ class Client:
                         is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
                                           == Primitives.get_local_ip())
 
-                        if is_cluster_rep or len(page_lines) <= network_size-1:
+                        if is_cluster_rep and len(page_lines) <= network_size-1:
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -312,7 +312,7 @@ class Client:
         except OSError:
             self.disconnect(connection)
 
-    def broadcast(self, message, do_mesh_propagation=None):
+    def broadcast(self, message, do_mesh_propagation="not set"):
         global ring_prop
         # do_message_propagation=None means use global config in nodeState[12]
 
@@ -322,11 +322,11 @@ class Client:
         # If not bootstrapped, do ring network propagation. Else, do fully-complete style propagation.
         message_list = self.read_nodestate(1)
 
-        if do_mesh_propagation == None:
+        if do_mesh_propagation == "not set":
             do_mesh_propagation = self.read_nodestate(12)
 
         if not do_mesh_propagation:
-
+            Primitives.log("Message propagation mode: ring", in_log_level="Debug")
             # Network not bootstrapped yet, do ring network propagation
             if message[:16] != ring_prop:
                 message = ring_prop + ":" + message
@@ -336,9 +336,6 @@ class Client:
             """ network bootstrapped or do_mesh_propagation override is active, do fully-complete/mesh style
                 message propagation """
             Primitives.log("Message propagation mode: fully-complete/mesh", in_log_level="Debug")
-
-        else:
-            Primitives.log("Message propagation mode: ring", in_log_level="Debug")
 
         for connection in net_tuple:
             self.send(connection, message, sign=False)  # Send a message to each node( = Broadcast)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -658,7 +658,7 @@ class Client:
                         is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
                                           == Primitives.get_local_ip())
 
-                        if is_cluster_rep or len(page_lines) > round(network_size/2):
+                        if is_cluster_rep or len(page_lines) == round(network_size/2):
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)
 
@@ -786,7 +786,7 @@ class Client:
                         election_list = self.read_nodestate(9)
                         is_cluster_rep = self.read_nodestate(11)
 
-                        if module_loaded == "discover":
+                        if module_loaded == "discovery":
                             # TODO: Make this support multiple peer discoveries without reinitializing
 
                             hosts_pagefile = ''.join(

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -898,6 +898,7 @@ class Client:
 
                     Primitives.log(str(len(this_campaign_list)) + " nodes have cast votes for "+election_details[0])
                     Primitives.log("Network size: "+str(network_size))
+
                     # Wait for all votes to be cast
                     if len(this_campaign_list) == network_size:
                         campaign_ints = []
@@ -931,7 +932,6 @@ class Client:
                             self.write_nodestate(nodeState, 11, False)  # set is_cluster_rep = False
 
                         # Cleanup
-                        self.write_nodestate(nodeState, 8, [])  # Clear the campaign_list
                         self.write_nodestate(nodeState, 7, 0)   # reset this_campaign to 0
                         self.write_nodestate(nodeState, 10, False)  # clear ongoing_election
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -416,11 +416,15 @@ class Client:
 
         sleep(random.uniform(0.008, 0.05))  # 8mS - 50mS
 
+        print("Full message " + full_message)
+
         if sig == ring_prop:
-            message.replace(message[:16], '')  # Remove the ring-propagation deliminator
+
+            message = message[17:]  # Remove the ring-propagation deliminator
             message_sig = message[:16]  # Signature after removing ring_prop
 
             sig = message_sig
+            message = message[17:]  # Remove the signature
 
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
@@ -434,6 +438,8 @@ class Client:
 
         # Do respond to messages we have yet to respond to.
         elif sig not in message_list or sig == no_prop:
+            print("Message: "+message)
+
 
             # e.x "Client -> Received: echo (ffffffffffffffff) from: 127.0.0.1"
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -420,15 +420,17 @@ class Client:
 
         if sig == ring_prop:
 
-            message = message[17:]  # Remove the ring-propagation deliminator
+            message = full_message[17:]  # Remove the ring-propagation deliminator
             message_sig = message[:16]  # Signature after removing ring_prop
 
             sig = message_sig
-            message = message[17:]  # Remove the signature
+            message = message[17:]  # remove the signature
 
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)
+            print("Message after ring_prop processing: "+message)
+
 
         # Don't respond to messages we've already responded to.
         if sig in message_list:

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -658,7 +658,7 @@ class Client:
                         is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
                                           == Primitives.get_local_ip())
 
-                        if is_cluster_rep or len(page_lines) == network_size:
+                        if is_cluster_rep or len(page_lines) > round(network_size/2):
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)
 
@@ -1016,7 +1016,7 @@ class Client:
                 print("Is cluster rep: "+str(is_cluster_rep))
                 discover.start(net_tuple, op_id, is_cluster_rep)
 
-            # Ring Network --> Fully-Complete/Mesh network bootstrapping routine
+            # Ring Network --> Mesh network bootstrapping routine
             if message.startswith("bootstrap:"):
                 arguments = Primitives.parse_cmd(message)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -960,8 +960,6 @@ class Client:
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)
 
-                # Callback to discover module
-                discover.start(net_tuple, op_id, self.read_nodestate(11))
 
             # Ring Network --> Fully-Complete/Mesh network bootstrapping routine
             if message.startswith("bootstrap:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -637,14 +637,17 @@ class Client:
 
                 page_contents = ''.join(page_lines)
 
-                if arguments[1] == "discovery":
-                    is_cluster_rep = self.read_nodestate(11)
+                try:
+                    if arguments[1] == "discovery":
+                        is_cluster_rep = self.read_nodestate(11)
 
-                    if is_cluster_rep or len(page_lines) == network_size:
-                        sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                        self.broadcast(sync_msg, do_mesh_propagation=True)
+                        if is_cluster_rep or len(page_lines) == network_size:
+                            sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                            self.broadcast(sync_msg, do_mesh_propagation=True)
 
-                else:
+                # Else if arguments[1] doesn't exist queue a normal fetch: routine
+                except TypeError:
+
                     sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                     self.broadcast(sync_msg, do_mesh_propagation=True)
 
@@ -659,6 +662,8 @@ class Client:
                 page_id = message[5:][:16]  # First 16 bytes after removing the 'sync:' flag
                 sync_data = message[22:]
 
+                print("Message: ")
+                print("\n\nSync Data: "+sync_data)
                 Primitives.log("Syncing " + sync_data + " into page:" + page_id, in_log_level="Debug")
 
                 file_path = "../inter/mem/" + page_id + ".bin"
@@ -849,6 +854,8 @@ class Client:
                                    "Attempting to initiate our election protocol with any information we"
                                    "can collect.", in_log_level="Warning")
                     os.chdir(original_path)
+                    self.write_nodestate(nodeState, 10, True)  # set ongoing_election = True
+
                     election_details = Primitives.parse_cmd(message)  # [reason, token]
 
                     # Before we (hopefully) receive a vote flag: the election list is empty. Populate it

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -879,7 +879,7 @@ class Client:
                 # This node has initialized it's election_list, do actual campaign work...
                 # If election_list[election_tuple_index] is not -1 or "TBD" then that election has already completed
                 # so we don't want to disrupt it by continuing to campaign after-the-fact...
-                elif election_list[election_tuple_index] == "TBD":
+                elif election_list[election_tuple_index][0] == "TBD":
 
                     campaign_tuple = tuple(election_details)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -879,7 +879,7 @@ class Client:
                 # This node has initialized it's election_list, do actual campaign work...
                 # If election_list[election_tuple_index] is not -1 or "TBD" then that election has already completed
                 # so we don't want to disrupt it by continuing to campaign after-the-fact...
-                elif election_list[election_tuple_index][0] == "TBD":
+                elif election_list[election_tuple_index][1] == "TBD":
 
                     campaign_tuple = tuple(election_details)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -878,7 +878,6 @@ class Client:
 
                 election_details = Primitives.parse_cmd(message)  # ("reason", "representative")
                 reason = election_details[0]
-                candidate = election_details[1]
 
                 election_list = self.read_nodestate(9)
                 election_tuple_index = Primitives.find_election_index(election_list, reason)
@@ -930,7 +929,7 @@ class Client:
                         for campaign_tuple in campaign_list:
                             if campaign_tuple[1] == winning_token:
                                 winning_reason = campaign_tuple[0]
-                                winning_candidate = campaign_tuple[1]
+                                winning_candidate = campaign_tuple[2]
 
                         election_log_msg = str(winning_token) + " won the election for: " + winning_reason
                         Primitives.log(election_log_msg, in_log_level="Info")

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1068,7 +1068,9 @@ class Client:
 
                 # Propagate the message to the rest of the network.
                 Primitives.log(str('Broadcasting: ' + full_message), in_log_level="Debug")
-                self.broadcast(full_message)
+
+                propagation_mode = self.read_nodestate(12)
+                self.broadcast(full_message, do_mesh_propagation=propagation_mode)
 
     def listen(self, connection):
         # Listen for incoming messages and call self.respond() to respond to them.

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -605,6 +605,8 @@ class Client:
             if message.startswith("fetch:"):
                 """ Broadcast the contents of [page id] to maintain distributed memory """
 
+                arguments = Primitives.parse_cmd(message)
+
                 page_id = message[6:]
 
                 # Read contents of page
@@ -620,9 +622,11 @@ class Client:
 
                 page_contents = ''.join(page_lines)
 
-                sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                self.broadcast(sync_msg, do_mesh_propagation=False)
-
+                if arguments[1] == "discovery":
+                    cluser_rep = self.read_nodestate(11)
+                    if cluser_rep:
+                        sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                        self.broadcast(sync_msg, do_mesh_propagation=False)
 
             # Write received pagefile data to disk
             if message.startswith("sync:"):
@@ -736,7 +740,7 @@ class Client:
                                 added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
 
                                 if len(added_peers) == network_size:
-                                    self.broadcast(self.prepare("fetch:" + hosts_pagefile), do_mesh_propagation=False)
+                                    self.broadcast(self.prepare("fetch:discovery" + hosts_pagefile), do_mesh_propagation=False)
 
                             module_loaded = ""
                             self.write_nodestate(nodeState, 5, module_loaded)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -970,6 +970,7 @@ class Client:
 
                 new_module_loaded = "discover"
                 self.write_nodestate(nodeState, 4, new_module_loaded)  # set module_loaded = "discover"
+                self.write_nodestate(nodeState, 12, True)  # Set network propagation mode to mesh
 
                 arguments = Primitives.parse_cmd(message)  # arguments[0] = op_id = name of pagefile
 
@@ -1053,6 +1054,7 @@ class Client:
 
                         # Great, bootstrapping was successful
                         # Set global message propagation mode to mesh
+                        # This was probably already run by sharepeers: assuming peer discovery was run...
                         do_mesh_propagation = self.read_nodestate(12)
 
                         if not do_mesh_propagation:

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -476,7 +476,7 @@ class Client:
 
                 # Inform localhost to follow suit.
                 localhost_connection = (localhost, "127.0.0.1")
-                self.send(localhost_connection, "rstop")
+                self.send(localhost_connection, "stop")
 
                 # The node will already be terminated by the time it gets to the end of the function and runs the
                 # message propagation algorithm; broadcast now, then stop

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -697,7 +697,7 @@ class Client:
                         print("(fetch) page lines: "+str(len(page_lines)))
                         print("(fetch) network size: "+str(network_size))
 
-                        if len(page_lines) < network_size:
+                        if is_cluster_rep and network_size > len(page_lines):
                             print("(fetch) syncing "+page_id+".bin"+"...")
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -651,8 +651,12 @@ class Client:
                 print("Page contents:")
 
                 try:
+                    election_list = self.read_nodestate(9)
+
                     if arguments[1] == "discovery":
-                        is_cluster_rep = self.read_nodestate(11)
+
+                        is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
+                                          == Primitives.get_local_ip())
 
                         if is_cluster_rep or len(page_lines) == network_size:
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -876,8 +876,9 @@ class Client:
                         campaign_ints = []
 
                         for campaign_tuple in campaign_list:
-                            campaign_int = campaign_tuple[1]
-                            campaign_ints.append(campaign_int)
+                            if campaign_tuple[0] == arguments[0]:
+                                campaign_int = campaign_tuple[1]
+                                campaign_ints.append(campaign_int)
 
                         print("Election complete: Campaign list:")
                         print("\n\n"+str(campaign_ints)+"\n\n")

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -928,6 +928,7 @@ class Client:
                             self.broadcast(elect_msg, do_mesh_propagation=True)
 
                             self.write_nodestate(nodeState, 11, True)  # set is_cluster_rep = True
+
                         else:
                             self.write_nodestate(nodeState, 11, False)  # set is_cluster_rep = False
 
@@ -974,11 +975,13 @@ class Client:
                     self.write_nodestate(nodeState, 9, new_election_list)
 
                     op_id = reason[10:]
-                    is_cluster_rep = self.read_nodestate(11)
+
+                    is_cluster_rep = (new_leader == Primitives.get_local_ip())
                     self.write_nodestate(nodeState, 10, False)  # Set ongoing_election = False
 
                     Primitives.log("(end of vote:) Ongoing election: "+str(self.read_nodestate(10)),
                                    in_log_level="Debug")
+                    print("is_cluster_rep: "+str(is_cluster_rep))
 
                     Primitives.log(str(new_election_list), in_log_level="Debug")
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -420,6 +420,8 @@ class Client:
             message.replace(message[:16], '')  # Remove the ring-propagation deliminator
             message_sig = message[:16]  # Signature after removing ring_prop
 
+            sig = message_sig
+
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -333,7 +333,6 @@ class Client:
         if do_mesh_propagation:
             """ network bootstrapped or do_mesh_propagation override is active, do fully-complete/mesh style
                 message propagation """
-
             Primitives.log("Message propagation mode: fully-complete/mesh", in_log_level="Debug")
 
         else:
@@ -802,10 +801,8 @@ class Client:
                 # Instead of making global changes to the nodeState, pass a new nodeState to vote
                 # with the appropriate parameters changed...
 
-                vote_nodeState = nodeState
-                vote_nodeState[12] = True  # Do mesh propagation
-
-                new_nodestate = vote.respond_start(message, vote_nodeState, ongoing_election)
+                new_nodestate = vote.respond_start(message, nodeState, ongoing_election)
+                self.overwrite_nodestate(new_nodestate)
 
             # Participate in a network election by entering as a candidate
             if message.startswith("campaign:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -658,7 +658,7 @@ class Client:
                         is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
                                           == Primitives.get_local_ip())
 
-                        if is_cluster_rep or len(page_lines) == round(network_size/2):
+                        if is_cluster_rep or len(page_lines) <= network_size-1:
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -879,6 +879,8 @@ class Client:
                             campaign_int = campaign_tuple[1]
                             campaign_ints.append(campaign_int)
 
+                        print("Election complete: Campaign list:")
+                        print("\n\n"+str(campaign_ints)+"\n\n")
                         winning_int = max(campaign_ints)
                         winning_reason = ""
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -328,8 +328,9 @@ class Client:
         if not do_mesh_propagation:
 
             # Network not bootstrapped yet, do ring network propagation
-            message = ring_prop + ":" + message
-            self.write_nodestate(nodeState, 1, message_list)
+            if message[:16] != ring_prop:
+                message = ring_prop + ":" + message
+                self.write_nodestate(nodeState, 1, message_list)
 
         if do_mesh_propagation:
             """ network bootstrapped or do_mesh_propagation override is active, do fully-complete/mesh style

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -66,9 +66,7 @@ class Client:
         if not void:
             return nodeState
 
-
-    @staticmethod
-    def read_nodestate(index):
+    def read_nodestate(self, index):
         return nodeState[index]
 
     @staticmethod
@@ -313,7 +311,8 @@ class Client:
         except OSError:
             self.disconnect(connection)
 
-    def broadcast(self, message, do_mesh_propagation=read_nodestate(12)):
+    def broadcast(self, message, do_mesh_propagation=None):
+        # do_message_propagation=None means use global config in nodeState[12]
 
         self.permute_network_tuple()
         net_tuple = self.read_nodestate(0)
@@ -321,7 +320,11 @@ class Client:
         # If not bootstrapped, do ring network propagation. Else, do fully-complete style propagation.
         message_list = self.read_nodestate(1)
 
+        if do_mesh_propagation == None:
+            do_mesh_propagation = self.read_nodestate(12)
+
         if not do_mesh_propagation:
+
             # Network not bootstrapped yet, do ring network propagation
             sig = message[:16]
             message_list.append(sig)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -949,8 +949,7 @@ class Client:
                 op_id = arguments[0]
 
                 # Get a list of all remote addresses
-                addresses = [item[1] for item in net_tuple if item[1] != "127.0.0.1"
-                             and item[1] != Primitives.get_local_ip() and item[1] != "localhost"]
+                addresses = Primitives.get_local_ip()
 
                 # Turn it into a string containing each address separated by newlines
                 _data = '\n'.join(addresses)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -989,9 +989,12 @@ class Client:
 
             # Write the remote addresses of all connected nodes to the pagefile established by $discover
             if message.startswith("sharepeers:"):
+                # sharepeers:pagefile
+
                 os.chdir(original_path)
                 import discover
 
+                election_list = self.read_nodestate(9)
                 new_module_loaded = "discover"
                 self.write_nodestate(nodeState, 4, new_module_loaded)  # set module_loaded = "discover"
                 self.write_nodestate(nodeState, 12, True)  # Set network propagation mode to mesh
@@ -1014,7 +1017,9 @@ class Client:
                 self.write_to_page(op_id, _data, signing=False)
 
                 # Callback to discover module
-                is_cluster_rep = self.read_nodestate(11)
+                is_cluster_rep = (Primitives.find_representative(election_list, "discovery-"+op_id)
+                                  == Primitives.get_local_ip())
+
                 print("Is cluster rep: "+str(is_cluster_rep))
                 discover.start(net_tuple, op_id, is_cluster_rep)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -897,6 +897,7 @@ class Client:
                     this_campaign_list = list(set(this_campaign_list))
 
                     Primitives.log(str(len(this_campaign_list)) + " nodes have cast votes for "+election_details[0])
+                    Primitives.log("Network size: "+str(network_size))
                     # Wait for all votes to be cast
                     if len(this_campaign_list) == network_size:
                         campaign_ints = []
@@ -952,6 +953,7 @@ class Client:
 
                 self.write_nodestate(nodeState, 9, new_election_list)  # Update the election list
 
+                print("New election list: "+str(new_election_list))
                 election_winner_msg = str(new_leader) + " won the election for:" + reason
                 Primitives.log(election_winner_msg, in_log_level="Info")
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -622,11 +622,16 @@ class Client:
 
                 page_contents = ''.join(page_lines)
 
-                if arguments[1] == "discovery":
-                    cluser_rep = self.read_nodestate(11)
-                    if cluser_rep:
-                        sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                        self.broadcast(sync_msg, do_mesh_propagation=False)
+                try:
+                    if arguments[1] == "discovery":
+                        cluser_rep = self.read_nodestate(11)
+                        if cluser_rep:
+                            sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                            self.broadcast(sync_msg, do_mesh_propagation=False)
+
+                except IndexError:
+                    sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
+                    self.broadcast(sync_msg, do_mesh_propagation=False)
 
             # Write received pagefile data to disk
             if message.startswith("sync:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -449,6 +449,19 @@ class Client:
 
         elif sig not in message_list or sig == no_prop:
 
+            # Append message signature to the message list, or in the case of sig=no_prop, do nothing.
+            if sig != no_prop and propagation_allowed:
+                new_message_list = list(message_list)
+                new_message_list.append(sig)
+                self.write_nodestate(nodeState, 1, new_message_list)
+                # End of respond()
+
+                # Propagate the message to the rest of the network.
+                Primitives.log(str('Broadcasting: ' + full_message), in_log_level="Debug")
+
+                propagation_mode = self.read_nodestate(12)
+                self.broadcast(full_message, do_mesh_propagation=propagation_mode)
+
             # Don't spam stdout with hundreds of kilobytes of text during pagefile syncing/file transfer
             if len(message) < 100 and "\n" not in message:
                 message_received_log = str('Received: ' + message
@@ -1092,19 +1105,6 @@ class Client:
                         if not do_mesh_propagation:
                             do_mesh_propagation = True
                             self.write_nodestate(nodeState, 12, do_mesh_propagation)
-
-            # Append message signature to the message list, or in the case of sig=no_prop, do nothing.
-            if sig != no_prop and propagation_allowed:
-                new_message_list = list(message_list)
-                new_message_list.append(sig)
-                self.write_nodestate(nodeState, 1, new_message_list)
-                # End of respond()
-
-                # Propagate the message to the rest of the network.
-                Primitives.log(str('Broadcasting: ' + full_message), in_log_level="Debug")
-
-                propagation_mode = self.read_nodestate(12)
-                self.broadcast(full_message, do_mesh_propagation=propagation_mode)
 
     def listen(self, connection):
         # Listen for incoming messages and call self.respond() to respond to them.

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -949,10 +949,7 @@ class Client:
                 op_id = arguments[0]
 
                 # Get a list of all remote addresses
-                addresses = Primitives.get_local_ip()
-
-                # Turn it into a string containing each address separated by newlines
-                _data = '\n'.join(addresses)
+                _data = Primitives.get_local_ip()
 
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -658,7 +658,7 @@ class Client:
                         is_cluster_rep = (Primitives.find_representative(election_list, "discovery-" + page_id)
                                           == Primitives.get_local_ip())
 
-                        if is_cluster_rep and len(page_lines) <= network_size-1:
+                        if is_cluster_rep and len(page_lines) < network_size+1:
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
                             self.broadcast(sync_msg, do_mesh_propagation=True)
 
@@ -997,7 +997,8 @@ class Client:
 
                     Primitives.log(str(new_election_list), in_log_level="Debug")
 
-                    discover.respond_start(net_tuple, op_id, is_cluster_rep)
+                    if is_cluster_rep:
+                        discover.respond_start(net_tuple, op_id, is_cluster_rep)
 
             # Write the remote addresses of all connected nodes to the pagefile established by $discover
             if message.startswith("sharepeers:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1014,7 +1014,9 @@ class Client:
                 self.write_to_page(op_id, _data, signing=False)
 
                 # Callback to discover module
-                discover.start(net_tuple, op_id, self.read_nodestate(11))
+                is_cluster_rep = self.read_nodestate(11)
+                print("Is cluster rep: "+str(is_cluster_rep))
+                discover.start(net_tuple, op_id, is_cluster_rep)
 
             # Ring Network --> Fully-Complete/Mesh network bootstrapping routine
             if message.startswith("bootstrap:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -988,7 +988,7 @@ class Client:
                 # Get a list of all remote addresses
                 _data = Primitives.get_local_ip()
                 addresses = [item[1] for item in net_tuple]
-                _data += "\n" + random.choice(addresses)
+                _data += "\n" + '\n'.join(addresses)
 
 
                 # Write it to page [op_id]

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -987,7 +987,7 @@ class Client:
 
                 # Get a list of all remote addresses
                 _data = Primitives.get_local_ip()
-                addresses = [item[0] for item in net_tuple]
+                addresses = [item[1] for item in net_tuple]
                 _data += "\n" + random.choice(addresses)
 
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -608,7 +608,7 @@ class Client:
 
                 arguments = Primitives.parse_cmd(message)
 
-                page_id = arguments[1]
+                page_id = arguments[0]
 
                 # Read contents of page
                 os.chdir(original_path)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -794,7 +794,7 @@ class Client:
 
                             added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
 
-                            if is_cluster_rep:
+                            if is_cluster_rep and existing_lines < network_size:
                                 self.broadcast(self.prepare("fetch:" + hosts_pagefile + ":discovery"),
                                                do_mesh_propagation=False)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -635,7 +635,7 @@ class Client:
                     if string[:1] == "#":
                         page_lines.remove(string)
 
-                page_contents = ''.join(page_lines)
+                page_contents = ''.join(set(list(page_lines)))
                 print("Page contents:")
                 try:
                     if arguments[1] == "discovery":

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -960,6 +960,8 @@ class Client:
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)
 
+                # Callback to discover module
+                discover.start(net_tuple, op_id, self.read_nodestate(11))
 
             # Ring Network --> Fully-Complete/Mesh network bootstrapping routine
             if message.startswith("bootstrap:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -854,7 +854,6 @@ class Client:
                                    "Attempting to initiate our election protocol with any information we"
                                    "can collect.", in_log_level="Warning")
                     os.chdir(original_path)
-                    self.write_nodestate(nodeState, 10, True)  # set ongoing_election = True
 
                     election_details = Primitives.parse_cmd(message)  # [reason, token]
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -730,7 +730,13 @@ class Client:
 
                             if is_cluster_rep:
 
-                                self.broadcast(self.prepare("fetch:" + hosts_pagefile), do_mesh_propagation=False)
+                                hosts_pagefile = ''.join(
+                                    [item[0][10:] for item in election_list if item[0][:10] == "discovery-"])
+
+                                added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
+
+                                if len(added_peers) == network_size:
+                                    self.broadcast(self.prepare("fetch:" + hosts_pagefile), do_mesh_propagation=False)
 
                             module_loaded = ""
                             self.write_nodestate(nodeState, 5, module_loaded)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -742,7 +742,7 @@ class Client:
                             added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
 
                             if is_cluster_rep:
-                                self.broadcast(self.prepare("fetch:discovery" + hosts_pagefile),
+                                self.broadcast(self.prepare("fetch:" + hosts_pagefile + ":discovery"),
                                                do_mesh_propagation=False)
 
                             module_loaded = ""

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -645,11 +645,11 @@ class Client:
 
                     if is_cluster_rep or len(page_lines) == network_size:
                         sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                        self.broadcast(sync_msg, do_mesh_propagation=False)
+                        self.broadcast(sync_msg, do_mesh_propagation=True)
 
                 else:
                     sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                    self.broadcast(sync_msg, do_mesh_propagation=False)
+                    self.broadcast(sync_msg, do_mesh_propagation=True)
 
             # Write received pagefile data to disk
             if message.startswith("sync:"):

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -312,7 +312,7 @@ class Client:
         except OSError:
             self.disconnect(connection)
 
-    def broadcast(self, message, do_mesh_propagation="not set"):
+    def broadcast(self, message, do_mesh_propagation=True):
         global ring_prop
         # do_message_propagation=None means use global config in nodeState[12]
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -411,7 +411,7 @@ class Client:
         # Introduce additional network mixing anonymity by introducing a random delay makes it difficult or
         # impossible to derive message paths through timing analysis alone.
 
-        sleep(random.uniform(0.008, 0.05))  # 8mS - 50mS
+        sleep(random.uniform(0.012, 0.08))  # 12mS - 80mS
 
         if sig == ring_prop:
 
@@ -636,7 +636,7 @@ class Client:
                         page_lines.remove(string)
 
                 page_contents = ''.join(page_lines)
-
+                print("Page contents:")
                 try:
                     if arguments[1] == "discovery":
                         is_cluster_rep = self.read_nodestate(11)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -603,11 +603,12 @@ class Client:
 
             # Retrieve a file from distributed memory by instructing all nodes to sync: the contents of some pagefile
             if message.startswith("fetch:"):
+                # fetch:pagefile:[optional task identifier]
                 """ Broadcast the contents of [page id] to maintain distributed memory """
 
                 arguments = Primitives.parse_cmd(message)
 
-                page_id = message[6:]
+                page_id = arguments[1]
 
                 # Read contents of page
                 os.chdir(original_path)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -741,7 +741,7 @@ class Client:
 
                             added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
 
-                            if len(added_peers) == network_size and is_cluster_rep:
+                            if is_cluster_rep:
                                 self.broadcast(self.prepare("fetch:discovery" + hosts_pagefile),
                                                do_mesh_propagation=False)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -376,7 +376,7 @@ class Client:
             data_line = str(data + "\n")
 
         file_path = ("../inter/mem/" + page_id + ".bin")
-        print('Writing '+data+ " to " + page_id + ".bin")
+        print('Writing '+data + " to " + page_id + ".bin")
 
         this_page = open(file_path, "a+")
         this_page.write(data_line)
@@ -416,8 +416,6 @@ class Client:
 
         sleep(random.uniform(0.008, 0.05))  # 8mS - 50mS
 
-        print("Full message " + full_message)
-
         if sig == ring_prop:
 
             message = full_message[17:]  # Remove the ring-propagation deliminator
@@ -429,8 +427,6 @@ class Client:
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)
-            print("Message after ring_prop processing: "+message)
-
 
         # Don't respond to messages we've already responded to.
         if sig in message_list:
@@ -440,14 +436,13 @@ class Client:
 
         # Do respond to messages we have yet to respond to.
         elif sig not in message_list or sig == no_prop:
-            print("Message: "+message)
-
-
-            # e.x "Client -> Received: echo (ffffffffffffffff) from: 127.0.0.1"
 
             if len(message) < 100 and "\n" not in message:
                 message_received_log = str('Received: ' + message
                                            + " (" + sig + ")" + " from: " + address)
+
+                # e.x "Client -> Received: echo (ffffffffffffffff) from: 127.0.0.1"
+
             else:
                 message_received_log = str('Received: ' + message[:16] + "(message truncated)"
                                            + " (" + sig + ")" + " from: " + address)
@@ -897,8 +892,6 @@ class Client:
                                 campaign_int = campaign_tuple[1]
                                 campaign_ints.append(campaign_int)
 
-                        print("Election complete: Campaign list:")
-                        print("\n\n"+str(campaign_ints)+"\n\n")
                         winning_int = max(campaign_ints)
                         winning_reason = ""
 
@@ -989,7 +982,6 @@ class Client:
                 _data = Primitives.get_local_ip()
                 addresses = [item[1] for item in net_tuple]
                 _data += "\n" + '\n'.join(addresses)
-
 
                 # Write it to page [op_id]
                 self.write_to_page(op_id, _data, signing=False)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -71,16 +71,20 @@ class Client:
         return nodeState[index]
 
     @staticmethod
-    def prepare(message):
+    def prepare(message, salt=True):
         """ Assign unique hashes to messages ready for transport.
             Returns (new hashed message) -> str """
 
         out = ""
 
         # Assign a timestamp
-        timestamp = str(datetime.datetime.utcnow())
-        stamped_message = timestamp + message
-        out += stamped_message
+        if salt:
+            timestamp = str(datetime.datetime.utcnow())
+            stamped_message = timestamp + message
+            out += stamped_message
+
+        else:
+            out += message
 
         # Generate the hash and append the message to it
         sig = sha3_224(out.encode()).hexdigest()[:16]
@@ -937,7 +941,7 @@ class Client:
                         this_campaign = self.read_nodestate(7)  # TODO: this could cause or suffer from race conditions
 
                         Primitives.log(winning_candidate+ " won the election for: " + winning_reason, in_log_level="Info")
-                        elect_msg = self.prepare("elect:" + winning_reason + ":" + winning_candidate)
+                        elect_msg = self.prepare("elect:" + winning_reason + ":" + winning_candidate, salt=False)
                         self.broadcast(elect_msg, do_mesh_propagation=True)
 
                         self.write_nodestate(nodeState, 11, True)  # set is_cluster_rep = True

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -700,7 +700,7 @@ class Client:
                         if is_cluster_rep and network_size > len(page_lines):
                             print("(fetch) syncing "+page_id+".bin"+"...")
                             sync_msg = self.prepare("sync:" + page_id + ":" + page_contents)
-                            self.broadcast(sync_msg, do_mesh_propagation=True)
+                            self.broadcast(sync_msg, do_mesh_propagation=False)
 
                         else:
                             print("(fetch) not syncing "+page_id+".bin"+"..."+"; All contributions"

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -739,15 +739,11 @@ class Client:
                             hosts_pagefile = ''.join(
                                 [item[0][10:] for item in election_list if item[0][:10] == "discovery-"])
 
-                            if is_cluster_rep:
+                            added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
 
-                                hosts_pagefile = ''.join(
-                                    [item[0][10:] for item in election_list if item[0][:10] == "discovery-"])
-
-                                added_peers = open("../inter/mem/" + hosts_pagefile + ".bin", "r+").readlines()
-
-                                if len(added_peers) == network_size:
-                                    self.broadcast(self.prepare("fetch:discovery" + hosts_pagefile), do_mesh_propagation=False)
+                            if len(added_peers) == network_size and is_cluster_rep:
+                                self.broadcast(self.prepare("fetch:discovery" + hosts_pagefile),
+                                               do_mesh_propagation=False)
 
                             module_loaded = ""
                             self.write_nodestate(nodeState, 5, module_loaded)

--- a/src/client/init_client.py
+++ b/src/client/init_client.py
@@ -9,7 +9,7 @@ def init(network_architecture):
     x = client.Client()
     x.initialize(port=port, net_architecture=network_architecture, remote_addresses=None,
                  command_execution=True, default_log_level="Info", modules=["corecount"],
-                 net_size=9)
+                 net_size=28)
 
 
 if __name__ == "__main__":

--- a/src/client/init_client.py
+++ b/src/client/init_client.py
@@ -9,7 +9,7 @@ def init(network_architecture):
     x = client.Client()
     x.initialize(port=port, net_architecture=network_architecture, remote_addresses=None,
                  command_execution=True, default_log_level="Info", modules=["corecount"],
-                 net_size=28)
+                 net_size=9)
 
 
 if __name__ == "__main__":

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -25,7 +25,7 @@ def initiate(net_tuple):
     injector.broadcast("vote:discovery-"+op_id, net_tuple)
 
 
-def respond_start(net_tuple, op_id, cluster_rep):
+def respond_start(nodeState, op_id, cluster_rep):
     """Called by the client's listener_thread after the 'discovery' election is complete"""
 
     print('Current directory: '+this_dir)
@@ -33,9 +33,22 @@ def respond_start(net_tuple, op_id, cluster_rep):
     _client = client.Client()
 
     os.chdir(this_dir)
+
+    net_tuple = nodeState[0]
+
     if cluster_rep:
-        _client.broadcast("newpage:"+op_id, net_tuple)  # Create a pagefile to store peer addresses in
-        _client.broadcast("sharepeers:"+op_id, net_tuple, do_mesh_propagation=False)  # Instruct nodes to append peer addresses to this pagefile
+        # Create a pagefile to store peer addresses in
+        new_nodeState = _client.broadcast("newpage:"+op_id, in_nodeState=nodeState)
+
+        # Instruct nodes to append peer addresses to this pagefile
+        new_nodeState = _client.broadcast("sharepeers:"+op_id, in_nodeState=new_nodeState, do_mesh_propagation=False)
+
+        return new_nodeState
+
+    else:
+
+        # Do nothing...
+        return nodeState
 
 
 def start(net_tuple, op_id, cluster_rep):

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -34,7 +34,7 @@ def respond_start(net_tuple, op_id, cluster_rep):
     if cluster_rep:
         injector = inject.NetworkInjector()
         injector.broadcast("newpage:"+op_id, net_tuple)  # Create a pagefile to store peer addresses in
-        injector.broadcast("sharepeers:"+op_id, net_tuple)  # Instruct nodes to append peer addresses to this pagefile
+        injector.broadcast("sharepeers:"+op_id, net_tuple, do_mesh_propagation=False)  # Instruct nodes to append peer addresses to this pagefile
 
 
 def start(net_tuple, op_id, cluster_rep):

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -45,5 +45,5 @@ def start(net_tuple, op_id, cluster_rep):
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        client.broadcast("fetch:" + op_id, net_tuple, do_mesh_propagation=False)
+        _client.broadcast("fetch:" + op_id, net_tuple, do_mesh_propagation=False)
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -29,12 +29,13 @@ def respond_start(net_tuple, op_id, cluster_rep):
     """Called by the client's listener_thread after the 'discovery' election is complete"""
 
     print('Current directory: '+this_dir)
-    import inject
+    import client
+    _client = client.Client()
+
     os.chdir(this_dir)
     if cluster_rep:
-        injector = inject.NetworkInjector()
-        injector.broadcast("newpage:"+op_id, net_tuple)  # Create a pagefile to store peer addresses in
-        injector.broadcast("sharepeers:"+op_id, net_tuple, do_mesh_propagation=False)  # Instruct nodes to append peer addresses to this pagefile
+        _client.broadcast("newpage:"+op_id, net_tuple)  # Create a pagefile to store peer addresses in
+        _client.broadcast("sharepeers:"+op_id, net_tuple, do_mesh_propagation=False)  # Instruct nodes to append peer addresses to this pagefile
 
 
 def start(net_tuple, op_id, cluster_rep):

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -45,5 +45,5 @@ def start(net_tuple, op_id, cluster_rep):
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        _client.broadcast("fetch:" + op_id, do_mesh_propagation=True)
+        _client.broadcast(_client.prepare("fetch:" + op_id), do_mesh_propagation=True)
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -38,10 +38,12 @@ def respond_start(nodeState, op_id, cluster_rep):
 
     if cluster_rep:
         # Create a pagefile to store peer addresses in
-        new_nodeState = _client.broadcast("newpage:"+op_id, in_nodeState=nodeState)
+        new_nodeState = _client.broadcast(_client.prepare("newpage:"+op_id),
+                                          in_nodeState=nodeState)
 
         # Instruct nodes to append peer addresses to this pagefile
-        new_nodeState = _client.broadcast("sharepeers:"+op_id, in_nodeState=new_nodeState, do_mesh_propagation=False)
+        new_nodeState = _client.broadcast(_client.prepare("sharepeers:"+op_id),
+                                          in_nodeState=new_nodeState, do_mesh_propagation=False)
 
         return new_nodeState
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -45,5 +45,6 @@ def start(net_tuple, op_id, cluster_rep):
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        _client.broadcast(_client.prepare("fetch:" + op_id), do_mesh_propagation=False)
+        print("!?!?!?!?! We are cluster rep!!!")
+        _client.broadcast(_client.prepare("fetch:" + op_id + ":discovery"), do_mesh_propagation=False)
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -45,5 +45,5 @@ def start(net_tuple, op_id, cluster_rep):
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        _client.broadcast(_client.prepare("fetch:" + op_id), do_mesh_propagation=True)
+        _client.broadcast(_client.prepare("fetch:" + op_id), do_mesh_propagation=False)
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -45,5 +45,5 @@ def start(net_tuple, op_id, cluster_rep):
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        _client.broadcast("fetch:" + op_id, net_tuple, do_mesh_propagation=False)
+        _client.broadcast("fetch:" + op_id, do_mesh_propagation=True)
 

--- a/src/inter/modules/discover.py
+++ b/src/inter/modules/discover.py
@@ -39,11 +39,11 @@ def respond_start(net_tuple, op_id, cluster_rep):
 
 def start(net_tuple, op_id, cluster_rep):
     """Called after addresses are written to page [op-id] """
-    import inject
+    import client
 
-    injector = inject.NetworkInjector()
+    _client = client.Client()
 
     # Synchronise discovered addresses across distributed filesystem...
     if cluster_rep:
-        injector.broadcast("fetch:" + op_id, net_tuple)
+        client.broadcast("fetch:" + op_id, net_tuple, do_mesh_propagation=False)
 

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -40,7 +40,7 @@ def respond_start(message, nodeState):
     print("Writing Data: " + data)
 
     # Write it to page [op_id]
-    client.write_to_page(op_id, data, signing=False)
+    _client.write_to_page(op_id, data, signing=False)
 
     # Callback to discover module
     is_cluster_rep = (_primitives.find_representative(election_list, "discovery-" + op_id)

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -37,7 +37,7 @@ def respond_start(message, nodeState):
 
     print(os.getcwd())
     file_path = os.path.abspath("../../inter/mem/" + op_id + ".bin")
-    raw_lines = list(set(open(file_path, "a+").readlines()))
+    raw_lines = list(set(open(file_path, "w+").readlines()))
 
     existing_lines = [raw_line for raw_line in raw_lines
                       if raw_line != "\n" and raw_line[:2] != "##"]
@@ -47,11 +47,10 @@ def respond_start(message, nodeState):
     if len(addresses) != 0:
         data += "\n" + random.choice(addresses)
 
-    if len(existing_lines) < 2:
-        print("Writing Data: " + data)
+    print("Writing Data: " + data)
 
-        # Write it to page [op_id]
-        _client.write_to_page(op_id, data, signing=False)
+    # Write it to page [op_id]
+    _client.write_to_page(op_id, data, signing=False)
 
     # Callback to discover module
     is_cluster_rep = (_primitives.find_representative(election_list, "discovery-" + op_id)

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -47,10 +47,11 @@ def respond_start(message, nodeState):
     if len(addresses) != 0:
         data += "\n" + random.choice(addresses)
 
-    print("Writing Data: " + data)
+    if len(existing_lines) < 2:
+        print("Writing Data: " + data)
 
-    # Write it to page [op_id]
-    _client.write_to_page(op_id, data, signing=False)
+        # Write it to page [op_id]
+        _client.write_to_page(op_id, data, signing=False)
 
     # Callback to discover module
     is_cluster_rep = (_primitives.find_representative(election_list, "discovery-" + op_id)

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -35,7 +35,7 @@ def respond_start(message, nodeState):
     print("Local IP: " + data)
 
     file_path = "../inter/mem/" + op_id + "/bin"
-    raw_lines = list(set(open(file_path).readlines()))
+    raw_lines = list(set(open(file_path, "a+").readlines()))
 
     existing_lines = [raw_line for raw_line in raw_lines
                       if raw_line != "\n" and raw_line[:2] != "##"]

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -35,7 +35,8 @@ def respond_start(message, nodeState):
 
     print("Local IP: " + data)
 
-    file_path = "../../inter/mem/" + op_id + "/bin"
+    print(os.getcwd())
+    file_path = os.path.abspath("../../inter/mem/" + op_id + ".bin")
     raw_lines = list(set(open(file_path, "a+").readlines()))
 
     existing_lines = [raw_line for raw_line in raw_lines

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -18,6 +18,7 @@ _primitives = primitives.Primitives('Client', 'Debug')
 
 def respond_start(message, nodeState):
     """Called by the client's listener_thread when it received a vote: flag"""
+    os.chdir(this_dir)
 
     net_tuple = nodeState[0]
     election_list = nodeState[9]
@@ -34,7 +35,7 @@ def respond_start(message, nodeState):
 
     print("Local IP: " + data)
 
-    file_path = "../inter/mem/" + op_id + "/bin"
+    file_path = "../../inter/mem/" + op_id + "/bin"
     raw_lines = list(set(open(file_path, "a+").readlines()))
 
     existing_lines = [raw_line for raw_line in raw_lines

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import random
+
+# Allow us to import the client
+this_dir = os.path.dirname(os.path.realpath(__file__))
+os.chdir(this_dir)
+
+sys.path.insert(0, (os.path.abspath('../../client')))
+sys.path.insert(0, (os.path.abspath('../../server')))
+
+import primitives
+import client
+
+_client = client.Client()
+_primitives = primitives.Primitives('Client', 'Debug')
+
+
+def respond_start(message, nodeState):
+    """Called by the client's listener_thread when it received a vote: flag"""
+
+    net_tuple = nodeState[0]
+    election_list = nodeState[9]
+
+    arguments = _primitives.parse_cmd(message)  # arguments[0] = op_id = name of pagefile
+    op_id = arguments[0]
+
+    new_module_loaded = "discover"
+
+    nodeState = _client.write_nodestate(nodeState, 4, new_module_loaded, void=False)  # set module_loaded = "discover"
+    nodeState = _client.write_nodestate(nodeState, 12, True, void=False)  # Set network propagation mode to mesh
+
+    data = _primitives.get_local_ip()
+
+    print("Local IP: " + data)
+
+    addresses = [item[1] for item in net_tuple]
+    data += "\n" + '\n'.join(addresses)
+
+    print("Writing Data: " + data)
+
+    # Write it to page [op_id]
+    client.write_to_page(op_id, data, signing=False)
+
+    # Callback to discover module
+    is_cluster_rep = (_primitives.find_representative(election_list, "discovery-" + op_id)
+                      == _primitives.get_local_ip())
+
+    print("Is cluster rep: " + str(is_cluster_rep))
+
+    return nodeState, op_id, is_cluster_rep

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -34,8 +34,16 @@ def respond_start(message, nodeState):
 
     print("Local IP: " + data)
 
-    addresses = [item[1] for item in net_tuple]
-    data += "\n" + '\n'.join(addresses)
+    file_path = "../inter/mem/" + op_id + "/bin"
+    raw_lines = list(set(open(file_path).readlines()))
+
+    existing_lines = [raw_line for raw_line in raw_lines
+                      if raw_line != "\n" and raw_line[:2] != "##"]
+
+    addresses = [item[1] for item in net_tuple if item not in existing_lines]
+
+    if len(addresses) != 0:
+        data += "\n" + random.choice(addresses)
 
     print("Writing Data: " + data)
 

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -25,7 +25,7 @@ def respond_start(message, nodeState):
     arguments = _primitives.parse_cmd(message)  # arguments[0] = op_id = name of pagefile
     op_id = arguments[0]
 
-    new_module_loaded = "discover"
+    new_module_loaded = "discovery"
 
     nodeState = _client.write_nodestate(nodeState, 4, new_module_loaded, void=False)  # set module_loaded = "discover"
     nodeState = _client.write_nodestate(nodeState, 12, True, void=False)  # Set network propagation mode to mesh

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -44,7 +44,7 @@ def respond_start(message, nodeState):
                       if raw_line != "\n" and raw_line[:2] != "##"]
 
     addresses = [item[1] for item in net_tuple if item not in existing_lines]
-    
+
     for address in addresses:
         data += "\n"+address
 

--- a/src/inter/modules/sharepeers.py
+++ b/src/inter/modules/sharepeers.py
@@ -28,7 +28,7 @@ def respond_start(message, nodeState):
 
     new_module_loaded = "discovery"
 
-    nodeState = _client.write_nodestate(nodeState, 4, new_module_loaded, void=False)  # set module_loaded = "discover"
+    nodeState = _client.write_nodestate(nodeState, 5, new_module_loaded, void=False)  # set module_loaded = "discover"
     nodeState = _client.write_nodestate(nodeState, 12, True, void=False)  # Set network propagation mode to mesh
 
     data = _primitives.get_local_ip()
@@ -39,13 +39,14 @@ def respond_start(message, nodeState):
     file_path = os.path.abspath("../../inter/mem/" + op_id + ".bin")
     raw_lines = list(set(open(file_path, "w+").readlines()))
 
+
     existing_lines = [raw_line for raw_line in raw_lines
                       if raw_line != "\n" and raw_line[:2] != "##"]
 
     addresses = [item[1] for item in net_tuple if item not in existing_lines]
-
-    if len(addresses) != 0:
-        data += "\n" + random.choice(addresses)
+    
+    for address in addresses:
+        data += "\n"+address
 
     print("Writing Data: " + data)
 

--- a/src/inter/modules/vote.py
+++ b/src/inter/modules/vote.py
@@ -49,6 +49,6 @@ def respond_start(message, nodeState, ongoing_election):
 
         _primitives.log("Campaigning for " + str(campaign_int), in_log_level="Info")
         campaign_msg = _client.prepare("campaign:" + reason + ":" + str(campaign_int))
-        _client.broadcast(campaign_msg)
+        _client.broadcast(campaign_msg, do_mesh_propagation=True)
 
     return new_nodestate

--- a/src/inter/modules/vote.py
+++ b/src/inter/modules/vote.py
@@ -49,10 +49,12 @@ def respond_start(reason, nodeState):
         # Generate a campaign: integer and call campaign for (reason, localhost)
 
         campaign_int = random.randint(1, 2 ** 128)
+        local_ip = _primitives.get_local_ip()
+
         new_nodestate = _client.write_nodestate(new_nodestate, 7, campaign_int, void=False)
 
         _primitives.log("Campaigning for " + str(campaign_int), in_log_level="Info")
-        campaign_msg = _client.prepare("campaign:" + reason + ":" + str(campaign_int))
+        campaign_msg = _client.prepare("campaign:" + reason + ":" + str(campaign_int)+":"+local_ip)
         _client.broadcast(campaign_msg, do_mesh_propagation=True)
 
     else:

--- a/src/inter/modules/vote.py
+++ b/src/inter/modules/vote.py
@@ -45,7 +45,7 @@ def respond_start(message, nodeState, ongoing_election):
         new_nodestate = _client.write_nodestate(new_nodestate, 9, election_list, void=False)
 
         campaign_int = random.randint(1, 2 ** 128)
-        new_nodestate = _client.write_nodestate(nodeState, 7, campaign_int, void=False)
+        new_nodestate = _client.write_nodestate(new_nodestate, 7, campaign_int, void=False)
 
         _primitives.log("Campaigning for " + str(campaign_int), in_log_level="Info")
         campaign_msg = _client.prepare("campaign:" + reason + ":" + str(campaign_int))

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -422,6 +422,12 @@ class Server:
 
                     self.send(localhost_connection, full_message, signing=False)
 
+        # If message propagation allows, forward all received message to client as no_prop.
+        if sig != no_prop and sig != ring_prop:
+            message_to_client = no_prop+message
+            localhost_connection = (localhost, "127.0.0.1")
+            self.send(localhost_connection, message_to_client)
+
     def disconnect(self, connection, disallow_local_disconnect=True):
         """Try to disconnect from a socket as cleanly as possible.
            Doesn't return anything. """

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -282,11 +282,11 @@ class Server:
             return
 
         if sig == ring_prop:
-            message = message[17:]  # Remove the ring_prop delimiter
+            message = full_message[17:]  # Remove the ring-propagation deliminator
             message_sig = message[:16]  # Signature after removing ring_prop
 
             sig = message_sig
-            message = message[17:]  # Remove the signature
+            message = message[17:]  # remove the signature
 
             new_message_list = list(message_list)
             new_message_list.append(message_sig)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -140,7 +140,7 @@ class Server:
 
                 self.disconnect(connection)
 
-    def broadcast(self, message, do_mesh_propagation="not set"):
+    def broadcast(self, message, do_mesh_propagation=True):
         global ring_prop
         # do_message_propagation=None means use global config in nodeState[12]
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -283,7 +283,8 @@ class Server:
         if sig == ring_prop:
             message.replace(message[:16], '')  # Remove the ring-propagation deliminator
             message_sig = message[:16]  # Signature after removing ring_prop
-
+            sig = message_sig
+            
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -213,9 +213,13 @@ class Server:
         net_tuple = self.read_nodestate(0)
 
         # 1. Kill localhost client
-        localhost_socket = self.lookup_socket("127.0.0.1")
-        localhost_connection = (localhost_socket, "127.0.0.1")
-        self.send(localhost_connection, "stop")
+        try:
+            localhost_socket = self.lookup_socket("127.0.0.1")
+            localhost_connection = (localhost_socket, "127.0.0.1")
+            self.send(localhost_connection, "stop")
+
+        except ConnectionRefusedError:
+            pass        # Localhost is already disconnected
 
         log_msg = "Attempting to gracefully disconnect and disassociate from all clients..."
         Primitives.log(log_msg, in_log_level="Info")

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -264,6 +264,7 @@ class Server:
 
         net_tuple = self.read_nodestate(0)
         message_list = self.read_nodestate(1)
+        do_ring_prop = False  # If true, bypass message signature check
 
         try:
             address = connection[1]
@@ -281,10 +282,12 @@ class Server:
             return
 
         if sig == ring_prop:
-            message.replace(message[:16], '')  # Remove the ring-propagation deliminator
+            message = message[17:]  # Remove the ring_prop delimiter
             message_sig = message[:16]  # Signature after removing ring_prop
+
             sig = message_sig
-            
+            message = message[17:]  # Remove the signature
+
             new_message_list = list(message_list)
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -292,6 +292,14 @@ class Server:
             new_message_list.append(message_sig)
             self.write_nodestate(nodeState, 1, new_message_list)
 
+            # Now, forward message to localhost as no_prop in case
+            # message propagation path didn't include this node's client
+            # (This behavior is technically permitted in ring mode)
+
+            localhost_message = no_prop + message
+            localhost_connection = (localhost, "127.0.0.1")
+            self.send(localhost_connection, localhost_message, signing=False)
+
         # Server received a unique message. Respond accordingly.
         if sig not in message_list:
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -155,8 +155,10 @@ class Server:
 
         if not do_mesh_propagation:
             # Network not bootstrapped yet, do ring network propagation
-            message = ring_prop + ":" + message
-            self.write_nodestate(nodeState, 1, message_list)
+
+            if message[:16] != ring_prop:
+                message = ring_prop + ":" + message
+                self.write_nodestate(nodeState, 1, message_list)
 
         if do_mesh_propagation:
             """ network bootstrapped or do_mesh_propagation override is active, do fully-complete/mesh style

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -278,6 +278,7 @@ class Server:
 
              If [connection] is localhost then the client is already dead (hence the receive error);
              Permit localhost disconnect..."""
+
             self.disconnect(connection, disallow_local_disconnect=False)
             return
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -140,7 +140,7 @@ class Server:
 
                 self.disconnect(connection)
 
-    def broadcast(self, message, do_mesh_propagation=None):
+    def broadcast(self, message, do_mesh_propagation="not set"):
         global ring_prop
         # do_message_propagation=None means use global config in nodeState[12]
 
@@ -150,7 +150,7 @@ class Server:
         # If not bootstrapped, do ring network propagation. Else, do fully-complete style propagation.
         message_list = self.read_nodestate(1)
 
-        if do_mesh_propagation == None:
+        if do_mesh_propagation == "not set":
             do_mesh_propagation = self.read_nodestate(6)
 
         if not do_mesh_propagation:


### PR DESCRIPTION
**- Improve overall stability and code cleanliness**

**- Reduce or eliminate possibility of various protocol-related race conditions in primitive functions (broadcast, vote, campaign, sync, fetch)**

**- Improve efficacy of built-in peer discovery algorithim on larger networks.**

    This will be replaced in a future commit by a much more stable
    algorithm which reliably work(and scale linearly) on network of 
    essentially infinite size; It won't really on rapidly syncing changes
    to pagefiles in and subsequently fetching them in real time, which 
    isn't stable or scalable. Axonet's distributed  random-access network 
    paging wasn't implemented for this use case...)

**- Calculate values of some nodestate variables which affect critical network function in real-time instead of relying on nodeState to actually be up-to-date at the exact moment we read it.**

- **Add a `do_mesh_propagation` argument to client/server `broadcast` function which allows whatever code that calls it to manually specify a message propagation mode** which, if set, will take precedence of whatever is set in nodeState. This allows mesh propagated messages to be sent in ring mode without overriding the nodeState and relying in the broadcast function to be executed by python _after_ that operation is complete. 

- **Modularize campaign flag**

- **Remove campaign's dependency on vote: being received and processed before executing properly**
